### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     pull_request:
         branches: [main]
 
+permissions:
+    contents: read
+
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/thomasglauser/thomas.glauser.dev/security/code-scanning/1](https://github.com/thomasglauser/thomas.glauser.dev/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify `contents: read`, which is sufficient for the current workflow since it only needs to read repository contents to install dependencies, lint, and build the project. This change ensures that no unnecessary write permissions are granted to the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
